### PR TITLE
Updated location of install script on homepage and added install.sh

### DIFF
--- a/public/install.sh
+++ b/public/install.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+curl -fsSL https://raw.githubusercontent.com/containers/ramalama/s/install.sh | sh

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -87,8 +87,7 @@ function App() {
             </h2>
             <h3 className="install-h3">Linux and Mac:</h3>
             <p className="install-code">
-              <div>curl -fsSL https://raw.githubusercontent.com/</div>
-              <div>containers/ramalama/s/install.sh | bash</div>
+              <div>curl -fsSL https://ramalama.ai/install.sh | sh</div>
             </p>
             <h3 className="install-h3">RamaLama is also available on PyPi!</h3>
             <p className="install-code">pip install ramalama</p>


### PR DESCRIPTION
Changes the curl command to a nicer url

Instead of maintaining the script both here and in the [Ramalama repo ](https://github.com/containers/ramalama/blob/main/install.sh) the one I have added will just curl the install script from the Ramalama repo