### PR TITLE
Don't hide errors

### DIFF
--- a/public/install.sh
+++ b/public/install.sh
@@ -1,2 +1,5 @@
 #!/bin/bash
+
+set -euo pipefail
+
 curl -fsSL https://raw.githubusercontent.com/containers/ramalama/s/install.sh | bash


### PR DESCRIPTION
Without `set -euo pipefail` the script is unsafe and hiding errors.