### PR TITLE
Ensure the whole script is downloaded before executing

### DIFF
--- a/public/install.sh
+++ b/public/install.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
-set -euo pipefail
+main() {
+  set -euo pipefail
 
-curl -fsSL https://raw.githubusercontent.com/containers/ramalama/s/install.sh | bash
+  local url="https://raw.githubusercontent.com/containers/ramalama/s/install.sh"
+  curl -fsSL "$url" | bash
+}
+
+main "$@"
+


### PR DESCRIPTION
This protects against partail executions if the file is not fully pulled.