### PR TITLE
Use ramalama install.sh from main branch

### DIFF
--- a/public/install.sh
+++ b/public/install.sh
@@ -3,7 +3,7 @@
 main() {
   set -euo pipefail
 
-  local url="https://raw.githubusercontent.com/containers/ramalama/s/install.sh"
+  local url="https://raw.githubusercontent.com/containers/ramalama/main/install.sh"
   curl -fsSL "$url" | bash
 }
 


### PR DESCRIPTION
The 's' branch this was referencing is stale.

Fixes: https://github.com/containers/ramalama/issues/2818